### PR TITLE
new license name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache License",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",


### PR DESCRIPTION
I haven't found when or why, but python has changed what they call the apache license.  Now its "Apache Software License", as shown by this beautiful list of permissible license classifiers.  

https://pypi.python.org/pypi?%3Aaction=list_classifiers